### PR TITLE
Use safe transfer and update canForward

### DIFF
--- a/contracts/Lock.sol
+++ b/contracts/Lock.sol
@@ -76,9 +76,8 @@ contract Lock is AragonApp, IForwarder, IForwarderFee {
     * @param _numberWithdrawLocks The number of withdraw locks to attempt withdrawal from
     */
     function withdrawTokens(uint256 _numberWithdrawLocks) external {
-       _withdrawTokens(_numberWithdrawLocks);
+        _withdrawTokens(_numberWithdrawLocks);
     }
-
 
     /**
     * @notice Tells the forward fee token and amount of the Tollgate app

--- a/contracts/examples/Template.sol
+++ b/contracts/examples/Template.sol
@@ -43,6 +43,13 @@ contract TemplateBase is APMNamehash {
         }
     }
 
+    function latestVersionAppBase(bytes32 appId) public view returns (address base) {
+        Repo repo = Repo(PublicResolver(ens.resolver(appId)).addr(appId));
+        (,base,) = repo.getLatest();
+
+        return base;
+    }
+
     function installApp(Kernel dao, bytes32 appId) internal returns (address) {
         address instance = address(dao.newAppInstance(appId, latestVersionAppBase(appId)));
         emit InstalledApp(instance, appId);
@@ -53,13 +60,6 @@ contract TemplateBase is APMNamehash {
         address instance = address(dao.newAppInstance(appId, latestVersionAppBase(appId), new bytes(0), true));
         emit InstalledApp(instance, appId);
         return instance;
-    }
-
-    function latestVersionAppBase(bytes32 appId) public view returns (address base) {
-        Repo repo = Repo(PublicResolver(ens.resolver(appId)).addr(appId));
-        (,base,) = repo.getLatest();
-
-        return base;
     }
 }
 

--- a/test/LockTest.js
+++ b/test/LockTest.js
@@ -4,6 +4,7 @@ const { encodeCallScript } = require('@aragon/test-helpers/evmScript')
 const ExecutionTarget = artifacts.require('ExecutionTarget')
 const Lock = artifacts.require('LockMock')
 const MockErc20 = artifacts.require('TokenMock')
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
 
 import DaoDeployment from './helpers/DaoDeployment'
 import { deployedContract } from './helpers/helpers'
@@ -17,14 +18,14 @@ contract('Lock', ([rootAccount, ...accounts]) => {
   const INITIAL_LOCK_DURATION = 60 // seconds
   const INITIAL_LOCK_AMOUNT = 10
 
-  before(async () => {
+  before('deploy DAO', async () => {
     await daoDeployment.deployBefore()
     lockBase = await Lock.new()
     CHANGE_DURATION_ROLE = await lockBase.CHANGE_DURATION_ROLE()
     CHANGE_AMOUNT_ROLE = await lockBase.CHANGE_AMOUNT_ROLE()
   })
 
-  beforeEach(async () => {
+  beforeEach('install lock-app', async () => {
     await daoDeployment.deployBeforeEach(rootAccount)
     const newLockAppReceipt = await daoDeployment.kernel.newAppInstance('0x1234', lockBase.address, '0x', false, {
       from: rootAccount,
@@ -34,7 +35,7 @@ contract('Lock', ([rootAccount, ...accounts]) => {
   })
 
   describe('initialize(address _token, uint256 _lockDuration, uint256 _lockAmount)', () => {
-    beforeEach(async () => {
+    beforeEach('initialize lock-app', async () => {
       await lockForwarder.initialize(mockErc20.address, INITIAL_LOCK_DURATION, INITIAL_LOCK_AMOUNT)
     })
 
@@ -50,15 +51,19 @@ contract('Lock', ([rootAccount, ...accounts]) => {
       assert.isTrue(hasInitialized)
     })
 
+    it('checks it is forwarder', async () => {
+      assert.isTrue(await lockForwarder.isForwarder())
+    })
+
+    it('can forward', async () => {
+      assert.isTrue(await lockForwarder.canForward(rootAccount, '0x'))
+    })
+
     it("get's forwarding fee information", async () => {
       const [actualToken, actualLockAmount] = Object.values(await lockForwarder.forwardFee())
 
       assert.strictEqual(actualToken, mockErc20.address)
       assert.equal(actualLockAmount, INITIAL_LOCK_AMOUNT)
-    })
-
-    it('checks it is forwarder', async () => {
-      assert.isTrue(await lockForwarder.isForwarder())
     })
 
     describe('changeLockDuration(uint256 _lockDuration)', () => {
@@ -89,7 +94,7 @@ contract('Lock', ([rootAccount, ...accounts]) => {
       let executionTarget, script
       let addressLocks = 0
 
-      beforeEach(async () => {
+      beforeEach('create execution script', async () => {
         //create script
         executionTarget = await ExecutionTarget.new()
         const action = {
@@ -131,14 +136,14 @@ contract('Lock', ([rootAccount, ...accounts]) => {
         assert.equal(actualLockAmount, expectedLockAmount)
       })
 
-      it('cannot forward action without approving lock-app to make the transfer', async () => {
-        await assertRevert(lockForwarder.forward(script, { from: rootAccount }), 'LOCK_CAN_NOT_FORWARD')
+      it('cannot forward if sender does not approve lock-app to transfer tokens', async () => {
+        await assertRevert(lockForwarder.forward(script, { from: rootAccount }), 'LOCK_TRANSFER_REVERTED')
       })
 
       describe('withdrawTokens()', async () => {
         let lockCount = 3
 
-        beforeEach(async () => {
+        beforeEach('Forward actions', async () => {
           await mockErc20.approve(lockForwarder.address, lockCount * INITIAL_LOCK_AMOUNT, {
             from: rootAccount,
           })

--- a/test/LockTest.js
+++ b/test/LockTest.js
@@ -4,7 +4,6 @@ const { encodeCallScript } = require('@aragon/test-helpers/evmScript')
 const ExecutionTarget = artifacts.require('ExecutionTarget')
 const Lock = artifacts.require('LockMock')
 const MockErc20 = artifacts.require('TokenMock')
-const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
 
 import DaoDeployment from './helpers/DaoDeployment'
 import { deployedContract } from './helpers/helpers'

--- a/test/LockTest.js
+++ b/test/LockTest.js
@@ -184,7 +184,7 @@ contract('Lock', ([rootAccount, ...accounts]) => {
 
           //increase time
           await lockForwarder.mockIncreaseTime(INITIAL_LOCK_DURATION + 1)
-          await lockForwarder.withdrawTokens(lockCount, { from: rootAccount })
+          await lockForwarder.withdrawTokens()
 
           const actualLockCount = await lockForwarder.getWithdrawLocksCount(rootAccount)
           assert.equal(actualLockCount, expectedLockCount)


### PR DESCRIPTION
Changed the requirement for `canForward` to check only if the app is initialized. This is needed for the approval transaction to work when the client attempts to get the transaction path.

What is needed as a consequence of this change is to add `SafeERC20` lib to use `safeTransferFrom` function so we can check  that the transfer is made successfully before forwarding the action.

Updated tests to take into account this changes.

You can now deploy your DAO using the template and mint some tokens from the `tokenManager` app. This will require for you to approve 20 LKT tokens to the lock app first and then create the vote.

UI is still missing, you can see the design in #15 