### PR TITLE
Griefing ui

### DIFF
--- a/app/src/App.js
+++ b/app/src/App.js
@@ -21,12 +21,7 @@ function App() {
       <Main>
         <SyncIndicator visible={isSyncing} />
         <Header
-          primary={
-            <Title
-              text="Lock"
-              after={tokenSymbol && <Badge.App>{tokenSymbol}</Badge.App>}
-            />
-          }
+          primary={<Title text="Lock" after={tokenSymbol && <Badge.App>{tokenSymbol}</Badge.App>} />}
           secondary={
             locks.length > 0 ? (
               <MainButton
@@ -45,11 +40,7 @@ function App() {
           onClose={panelState.requestClose}
           onTransitionEnd={panelState.endTransition}
         >
-          <WithdrawLocks
-            panelOpened={panelState.opened}
-            locks={locks}
-            withdraw={actions.withdraw}
-          />
+          <WithdrawLocks panelOpened={panelState.opened} locks={locks} withdraw={actions.withdraw} />
         </SidePanel>
       </Main>
     </>

--- a/app/src/components/LockSettings.js
+++ b/app/src/components/LockSettings.js
@@ -8,6 +8,7 @@ import { formatTokenAmount, formatTime } from '../lib/math-utils'
 function LockSettings({
   duration,
   amount,
+  griefingFactor,
   tokenAddress,
   tokenName,
   tokenSymbol,
@@ -24,31 +25,24 @@ function LockSettings({
           </InfoRow>
           <InfoRow>
             <Text>Amount</Text>
-            <Text>{`${formatTokenAmount(
-              amount,
-              false,
-              tokenDecimals
-            )} ${tokenSymbol}`}</Text>
+            <Text>{`${formatTokenAmount(amount, false, tokenDecimals)} ${tokenSymbol}`}</Text>
           </InfoRow>
           <InfoRow>
             <Text>Token</Text>
             {network && tokenSymbol && (
-              <TokenBadge
-                address={tokenAddress}
-                name={tokenName}
-                symbol={tokenSymbol}
-                networkType={network.type}
-              />
+              <TokenBadge address={tokenAddress} name={tokenName} symbol={tokenSymbol} networkType={network.type} />
             )}
+          </InfoRow>
+          <InfoRow>
+            <Text>Griefing</Text>
+            <Duration>{griefingFactor} %</Duration>
           </InfoRow>
         </ul>
       </Box>
       <Box header="info" css={{ backgroundColor: theme.infoBackground }}>
         <Wrap>
           <IconAttention style={{ marginRight: '6px' }} />
-          <Text color={theme.infoSurfaceContent}>
-            You can withdraw your tokens once they unlock
-          </Text>
+          <Text color={theme.infoSurfaceContent}>You can withdraw your tokens once they unlock</Text>
         </Wrap>
       </Box>
     </>

--- a/app/src/components/Title.js
+++ b/app/src/components/Title.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
 import { useAragonApi, useAppState } from '@aragon/api-react'
-import { font } from '@aragon/ui'
 import MenuButton from './MenuButton/MenuButton'
 
 function Title({ text, after }) {

--- a/app/src/hooks/app-hooks.js
+++ b/app/src/hooks/app-hooks.js
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback } from 'react'
+import { useMemo, useCallback } from 'react'
 import { useAppState, useApi } from '@aragon/api-react'
 
 import { isUnlocked } from '../lib/lock-utils'

--- a/app/src/lib/lock-settings.js
+++ b/app/src/lib/lock-settings.js
@@ -1,7 +1,9 @@
+// contract getter | variableName | data type
 const lockSettings = [
   ['token', 'tokenAddress'],
   ['lockDuration', 'lockDuration', 'time'],
   ['lockAmount', 'lockAmount', 'bignumber'],
+  ['griefingFactor', 'griefingFactor', 'number'],
 ]
 
 export function hasLoadedLockSettings(state) {

--- a/app/src/screens/Locks.js
+++ b/app/src/screens/Locks.js
@@ -11,25 +11,23 @@ function Locks({ locks }) {
   const {
     lockAmount,
     lockDuration,
+    griefingFactor,
     tokenAddress,
     tokenName,
     tokenSymbol,
     tokenDecimals,
   } = useAppState()
 
+  console.log('grief', griefingFactor)
+
   return (
     <Split
-      primary={
-        <LockTable
-          locks={locks}
-          tokenSymbol={tokenSymbol}
-          tokenDecimals={tokenDecimals}
-        />
-      }
+      primary={<LockTable locks={locks} tokenSymbol={tokenSymbol} tokenDecimals={tokenDecimals} />}
       secondary={
         <LockSettings
           amount={lockAmount}
           duration={lockDuration}
+          griefingFactor={griefingFactor}
           tokenName={tokenName}
           tokenAddress={tokenAddress}
           tokenSymbol={tokenSymbol}

--- a/app/src/screens/Locks.js
+++ b/app/src/screens/Locks.js
@@ -18,8 +18,6 @@ function Locks({ locks }) {
     tokenDecimals,
   } = useAppState()
 
-  console.log('grief', griefingFactor)
-
   return (
     <Split
       primary={<LockTable locks={locks} tokenSymbol={tokenSymbol} tokenDecimals={tokenDecimals} />}

--- a/app/src/script.js
+++ b/app/src/script.js
@@ -18,7 +18,6 @@ retryEvery(() =>
 
 async function initialize(tokenAddress) {
   const tokenContract = app.external(tokenAddress, tokenAbi)
-  console.log('contract', tokenContract)
   return createStore(tokenContract)
 }
 
@@ -113,7 +112,6 @@ async function updateLockAmount(state, { newLockAmount }) {
 }
 
 async function updateGriefingFactor(state, { newGriefingFactor }) {
-  console.log('changed', newGriefingFactor)
   return {
     ...state,
     griefingFactor: newGriefingFactor,

--- a/app/src/script.js
+++ b/app/src/script.js
@@ -12,9 +12,7 @@ retryEvery(() =>
   app
     .call('token')
     .subscribe(initialize, err =>
-      console.error(
-        `Could not start background script execution due to the contract not loading token: ${err}`
-      )
+      console.error(`Could not start background script execution due to the contract not loading token: ${err}`)
     )
 )
 
@@ -48,6 +46,8 @@ async function createStore(tokenContract) {
           return updateLockDuration(nextState, returnValues)
         case 'ChangeLockAmount':
           return updateLockAmount(nextState, returnValues)
+        case 'ChangeGriefingFactor':
+          return updateGriefingFactor(nextState, returnValues)
         case 'NewLock':
           return newLock(nextState, returnValues)
         case 'Withdrawal':
@@ -87,9 +87,7 @@ async function updateConnectedAccount(state, { account }) {
   const locks = []
 
   for (let i = 0; i < lockCount; i++) {
-    let { unlockTime, lockAmount } = await app
-      .call('addressesWithdrawLocks', account, i)
-      .toPromise()
+    let { unlockTime, lockAmount } = await app.call('addressesWithdrawLocks', account, i).toPromise()
     locks.push({ unlockTime: marshallDate(unlockTime), lockAmount })
   }
 
@@ -100,17 +98,25 @@ async function updateConnectedAccount(state, { account }) {
   }
 }
 
-async function updateLockDuration({ settings, ...state }, { newLockDuration }) {
+async function updateLockDuration(state, { newLockDuration }) {
   return {
     ...state,
-    settings: { ...settings, duration: marshallDate(newLockDuration) },
+    lockDuration: marshallDate(newLockDuration),
   }
 }
 
-async function updateLockAmount({ settings, ...state }, { newLockAmount }) {
+async function updateLockAmount(state, { newLockAmount }) {
   return {
     ...state,
-    settings: { ...settings, amount: newLockAmount },
+    lockAmount: newLockAmount,
+  }
+}
+
+async function updateGriefingFactor(state, { newGriefingFactor }) {
+  console.log('changed', newGriefingFactor)
+  return {
+    ...state,
+    griefingFactor: newGriefingFactor,
   }
 }
 
@@ -126,10 +132,7 @@ async function newLock(state, { lockAddress, unlockTime, lockAmount }) {
   }
 }
 
-async function newWithdrawal(
-  state,
-  { withdrawalAddress, withdrawalLockCount }
-) {
+async function newWithdrawal(state, { withdrawalAddress, withdrawalLockCount }) {
   const { account, locks } = state
 
   //skip if no connected account or new withdrawl doesn't correspond to connected account
@@ -177,9 +180,7 @@ async function getLockSettings() {
         .then(value => ({ [key]: value }))
     )
   )
-    .then(settings =>
-      settings.reduce((acc, setting) => ({ ...acc, ...setting }), {})
-    )
+    .then(settings => settings.reduce((acc, setting) => ({ ...acc, ...setting }), {}))
     .catch(err => {
       console.error('Failed to load lock settings', err)
       // Return an empty object to try again later
@@ -188,9 +189,7 @@ async function getLockSettings() {
 }
 
 function getBlockNumber() {
-  return new Promise((resolve, reject) =>
-    app.web3Eth('getBlockNumber').subscribe(resolve, reject)
-  )
+  return new Promise((resolve, reject) => app.web3Eth('getBlockNumber').subscribe(resolve, reject))
 }
 
 function marshallDate(date) {

--- a/contracts/Lock.sol
+++ b/contracts/Lock.sol
@@ -158,10 +158,6 @@ contract Lock is AragonApp, IForwarder, IForwarderFee {
         runScript(_evmCallScript, new bytes(0), new address[](0));
     }
 
-    function testRadspec() public view returns (address) {
-        return msg.sender;
-    }
-
     function getWithdrawLocksCount(address _lockAddress) public view returns (uint256) {
         return addressesWithdrawLocks[_lockAddress].length;
     }

--- a/contracts/Lock.sol
+++ b/contracts/Lock.sol
@@ -135,7 +135,7 @@ contract Lock is AragonApp, IForwarder, IForwarderFee {
     }
 
     /**
-    * @notice Locks `@tokenAmount(self.token(): address, self.getGriefing(): uint + self.lockAmount(): uint)` tokens and forwards desired action
+    * @notice Locks `@tokenAmount(self.token(): address, self.getGriefing(): uint + self.lockAmount(): uint)` tokens and executes desired action
     * @dev IForwarder interface conformance. Consider using pretransaction on UI for necessary approval.
     *      Note that the Lock app has to be the first forwarder in the transaction path, it must be called by an EOA not another forwarder, in order for the griefing mechanism to work
     * @param _evmCallScript Script to execute

--- a/contracts/Lock.sol
+++ b/contracts/Lock.sol
@@ -38,6 +38,7 @@ contract Lock is AragonApp, IForwarder, IForwarderFee {
 
     event ChangeLockDuration(uint256 newLockDuration);
     event ChangeLockAmount(uint256 newLockAmount);
+    event ChangeGriefingFactor(uint256 newGriefingFactor);
     event NewLock(address lockAddress, uint256 unlockTime, uint256 lockAmount);
     event Withdrawal(address withdrawalAddress ,uint256 withdrawalLockCount);
 
@@ -81,7 +82,7 @@ contract Lock is AragonApp, IForwarder, IForwarderFee {
     */
     function changeGriefingFactor(uint256 _griefingFactor) external auth(CHANGE_GRIEFING_ROLE) {
         griefingFactor = _griefingFactor;
-        emit ChangeLockAmount(griefingFactor);
+        emit ChangeGriefingFactor(griefingFactor);
     }
 
     /**

--- a/test/LockTest.js
+++ b/test/LockTest.js
@@ -155,7 +155,7 @@ contract('Lock', ([rootAccount, ...accounts]) => {
     describe('getGriefing(address _sender)', () => {
       it("get's griefing amount and duration", async () => {
         const [actualGriefingAmount, actualGriefingDuration] = Object.values(
-          await lockForwarder.getGriefing(rootAccount)
+          await lockForwarder.getGriefing({ from: rootAccount })
         )
 
         assert.equal(actualGriefingAmount, 0)
@@ -179,7 +179,7 @@ contract('Lock', ([rootAccount, ...accounts]) => {
 
         it('griefing amount and duration increase for second lock', async () => {
           const [actualGriefingAmount, actualGriefingDuration] = Object.values(
-            await lockForwarder.getGriefing(rootAccount)
+            await lockForwarder.getGriefing({ from: rootAccount })
           )
 
           assert.equal(actualGriefingAmount, 5)
@@ -196,7 +196,7 @@ contract('Lock', ([rootAccount, ...accounts]) => {
           await lockForwarder.changeGriefingFactor(100)
 
           const [actualGriefingAmount, actualGriefingDuration] = Object.values(
-            await lockForwarder.getGriefing(rootAccount)
+            await lockForwarder.getGriefing({ from: rootAccount })
           )
 
           assert.equal(actualGriefingAmount, 10)


### PR DESCRIPTION
closes #38 

- [x] Includes griefing factor on the lock settings box.
- [x] Includes amount to lock on radspec.



Had to change `getGriefing()` function and instead of checking the input `_sender` address griefing amount, it checks for the `msg.sender`'s. 
Couldn't find a way to tell radspec the account's address that is going to lock tokens so this change was required.

The thing missing is showing also the lock duration in radspec but will create a new issue regarding that as it requires changing radspec itself. 

For the contract changes you can see them in [this](https://github.com/1Hive/lock-app/pull/47/commits/dcd8ce6ab566a4ab638ac68db09d4d8cca56fa77) commit