### PR TITLE
Rename withdrawTokens function and update tests

### DIFF
--- a/contracts/Lock.sol
+++ b/contracts/Lock.sol
@@ -88,7 +88,7 @@ contract Lock is AragonApp, IForwarder, IForwarderFee {
     /**
     * @notice Withdraw all withdrawable tokens
     */
-    function withdrawTokens() external {
+    function withdrawAllTokens() external {
         WithdrawLockLib.WithdrawLock[] storage addressWithdrawLocks = addressesWithdrawLocks[msg.sender];
         _withdrawTokens(msg.sender, addressWithdrawLocks.length);
     }

--- a/test/LockTest.js
+++ b/test/LockTest.js
@@ -350,7 +350,7 @@ contract('Lock', ([rootAccount, ...accounts]) => {
 
           //increase time
           await lockForwarder.mockIncreaseTime(INITIAL_LOCK_DURATION * lockCount + 1)
-          await lockForwarder.withdrawTokens()
+          await lockForwarder.withdrawAllTokens()
 
           const actualLockCount = await lockForwarder.getWithdrawLocksCount(rootAccount)
           assert.equal(actualLockCount, expectedLockCount)


### PR DESCRIPTION
Had to rename `withdrawTokens()` function as when calling the second `witdhrawTokens(uint256)`
function it would complain that the parameter length provided was incorrect.

Seems like it would not recognize that there's a second function that takes an argument value.

